### PR TITLE
Add channel auth

### DIFF
--- a/src/ChannelClient.php
+++ b/src/ChannelClient.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SturentsLib\Api;
+
+use SturentsLib\Api\Requests\SwaggerRequest;
+
+class ChannelClient extends SturentsClient {
+
+	private $display_key;
+
+	private $channel_id;
+
+	/**
+	 * FetchHouses constructor.
+	 * @param string $landlord_id
+	 * @param string $channel_id
+	 * @param string $display_key
+	 */
+	public function __construct($landlord_id, $channel_id, $display_key){
+		parent::__construct($landlord_id);
+		$this->channel_id = $channel_id;
+		$this->display_key = $display_key;
+	}
+
+	/**
+	 * @param SwaggerRequest $request
+	 * @return array
+	 */
+	protected function authQuery(SwaggerRequest $request){
+		$timestamp = time();
+		$auth = $this->generateAuth($timestamp);
+
+		return [
+			'auth' => $auth,
+			'timestamp' => $timestamp,
+			'channel' => $this->channel_id,
+		];
+	}
+
+	/**
+	 * @param string $timestamp
+	 * @return string
+	 */
+	protected function generateAuth($timestamp){
+		return hash_hmac('sha256', (string)$timestamp, (string)$this->display_key);
+	}
+}

--- a/src/Models/AuthError.php
+++ b/src/Models/AuthError.php
@@ -21,6 +21,12 @@ class AuthError extends SwaggerModel
 	 */
 	protected $auth;
 
+	/**
+	 * Indicates an issue with the provided "channel" token
+	 * @var string
+	 */
+	protected $channel;
+
 
 	/**
 	 * @return string
@@ -64,5 +70,26 @@ class AuthError extends SwaggerModel
 
 		return $this;
 	}
-}
 
+
+	/**
+	 * @return string
+	 */
+	public function getChannel()
+	{
+		return $this->channel;
+	}
+
+
+	/**
+	 * @param string $channel
+	 *
+	 * @return $this
+	 */
+	public function setChannel($channel)
+	{
+		$this->channel = $channel;
+
+		return $this;
+	}
+}

--- a/src/Models/PropertyManager.php
+++ b/src/Models/PropertyManager.php
@@ -1,0 +1,124 @@
+<?php
+namespace SturentsLib\Api\Models;
+
+/**
+ * ** This file was generated automatically, you might want to avoid editing it **
+ */
+class PropertyManager extends SwaggerModel
+{
+	/**
+	 * Pass this as the "landlord" field when requesting data for this account
+	 *
+	 * @var string
+	 */
+	protected $landlord;
+
+	/**
+	 * Title of this account on the StuRents website
+	 *
+	 * @var string
+	 */
+	protected $title;
+
+	/**
+	 * Title of the organisation this account belongs to on the StuRents website
+	 *
+	 * @var string
+	 */
+	protected $company_title;
+
+	/**
+	 * ID for the organisation this account belongs to on the StuRents website
+	 *
+	 * @var string
+	 */
+	protected $company;
+
+
+	/**
+	 * @return string
+	 */
+	public function getLandlord()
+	{
+		return $this->landlord;
+	}
+
+
+	/**
+	 * @param string $landlord
+	 *
+	 * @return $this
+	 */
+	public function setLandlord($landlord)
+	{
+		$this->landlord = $landlord;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getTitle()
+	{
+		return $this->title;
+	}
+
+
+	/**
+	 * @param string $title
+	 *
+	 * @return $this
+	 */
+	public function setTitle($title)
+	{
+		$this->title = $title;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getCompanyTitle()
+	{
+		return $this->company_title;
+	}
+
+
+	/**
+	 * @param string $company_title
+	 *
+	 * @return $this
+	 */
+	public function setCompanyTitle($company_title)
+	{
+		$this->company_title = $company_title;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getCompany()
+	{
+		return $this->company;
+	}
+
+
+	/**
+	 * @param string $company
+	 *
+	 * @return $this
+	 */
+	public function setCompany($company)
+	{
+		$this->company = $company;
+
+		return $this;
+	}
+}

--- a/src/Requests/GetSummary.php
+++ b/src/Requests/GetSummary.php
@@ -1,0 +1,27 @@
+<?php
+namespace SturentsLib\Api\Requests;
+
+/**
+ * Returns all property managers in the channel
+ */
+class GetSummary extends SwaggerRequest
+{
+	const URI = '/api/summary';
+	const METHOD = 'GET';
+
+
+	/**
+	 * @param SwaggerClient $client
+	 * @return string[]
+	 */
+	public function sendWith(SwaggerClient $client)
+	{
+		return $client->make($this, [
+			'200' => '\\SturentsLib\\Api\\Models\\PropertyManager',
+			'400' => '\\SturentsLib\\Api\\Models\\Error',
+			'401' => '\\SturentsLib\\Api\\Models\\AuthError',
+			'404' => '\\SturentsLib\\Api\\Models\\GetError',
+			'default' => '\\SturentsLib\\Api\\Models\\Error'
+		]);
+	}
+}

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -78,9 +78,11 @@ paths:
       summary: Returns properties for the authenticated property manager
       security:
         - PropertyManager: []
+          Timestamp: []
           Auth: []
         - Channel: []
           PropertyManager: []
+          Timestamp: []
           Auth: []
       parameters:
         - in: query
@@ -101,6 +103,33 @@ paths:
             A list of property objects
           schema:
             $ref: '#/definitions/ListProperties'
+        '400':
+          $ref: '#/definitions/Error'
+        '401':
+          $ref: '#/definitions/AuthError'
+        '404':
+          $ref: '#/definitions/GetError'
+        default:
+          $ref: '#/definitions/Error'
+  /summary:
+    get:
+      summary: Returns all property managers in the channel
+      security:
+        - Channel: []
+          PropertyManager: []
+          Timestamp: []
+          Auth: []
+      tags:
+        - Fetching data to make changes
+        - Properties
+      responses:
+        '200':
+          description: |
+            A list of property manager objects
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PropertyManager'
         '400':
           $ref: '#/definitions/Error'
         '401':
@@ -1301,6 +1330,24 @@ definitions:
         type: string
         description: |
           Pass this as the "schedule_id" field when creating/updating a contract
+  PropertyManager:
+    properties:
+      landlord:
+        type: string
+        description: |
+          Pass this as the "landlord" field when requesting data for this account
+      title:
+        type: string
+        description: |
+          Title of this account on the StuRents website
+      company_title:
+        type: string
+        description: |
+          Title of the organisation this account belongs to on the StuRents website
+      company:
+        type: string
+        description: |
+          ID for the organisation this account belongs to on the StuRents website
   BankAccount:
     properties:
       descriptor:

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -647,6 +647,9 @@ definitions:
       auth:
         type: string
         description: Indicates an issue with the provided "auth" token
+      channel:
+        type: string
+        description: Indicates an issue with the provided "channel" token
   SendDataError:
     description: |
       There were problems with the input data in the request body.

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -34,15 +34,16 @@ securityDefinitions:
     type: apiKey
     in: query
     name: timestamp
-    description: Unix eopch timestamp in seconds, used to prevent API replay
+    description: Unix epoch timestamp in seconds, used to prevent API replay
   Auth:
     type: apiKey
     in: query
     name: auth
     description: |
-      There are two types of API key, but both function identically when
-      making a request. The key types are "upload key" and "display key".
+      There are three types of API key, but all function identically when
+      making a request. The key types are "upload key", "display key", and "channel key".
       The "display key" is used ONLY for making GET /properties requests.
+      The "channel key" is used only when making a request with a channel value set.
       The "upload key" is used for all other requests.
 
       The "auth" query parameter will be an HMAC SHA256 of the request
@@ -245,7 +246,7 @@ paths:
   /tenancy-templates:
     get:
       summary: |
-        Returns tenancy templates for the authenticated property manager
+        Returns tenancy templates for the authenticated property manager.
         The IDs of these templates will be required to set up Contract
         entities using a specific tenancy template
       security:
@@ -271,7 +272,7 @@ paths:
   /payment-structures:
     get:
       summary: |
-        Returns payment schedules for the authenticated property manager
+        Returns payment schedules for the authenticated property manager.
         The IDs of these schedules will be required to set up Contract
         entities using a specific payment schedule
       security:


### PR DESCRIPTION
Added a new Client class that sets a channel id in the auth query in order to allow channel based access.
Added a channel property to the AuthError class for errors relating to the submitted channel value (as opposed to the landlord/auth values) to be mapped to.