### PR TITLE
add 429 response to /properties

### DIFF
--- a/src/Models/ContractCreation.php
+++ b/src/Models/ContractCreation.php
@@ -28,7 +28,7 @@ class ContractCreation extends ContractAbstract
 	 * A unique identifier for a Tenancy Template fetched from
 	 * the /tenancy-templates endpoint. A tenancy template
 	 * allows a tenancy to be created for tenants who are renting
-	 * the property and can sign for it on StuRents
+	 * the property and can sign for it on StuRents. For properties that are only listing for advertising, this field can be set to an empty string.
 	 *
 	 * @var string
 	 * @required
@@ -36,9 +36,9 @@ class ContractCreation extends ContractAbstract
 	protected $template_id;
 
 	/**
-	 * An array of one or more ScheduleOption entities describing how
+	 * An array of zero or more ScheduleOption entities describing how
 	 * the rent for this contract can be structured and what additional
-	 * conditions are applied.
+	 * conditions are applied. For the property to be bookable directly via the platform, at least one schedule must be provided.
 	 *
 	 * @var ScheduleOption[]
 	 * @required

--- a/src/Models/RateLimitError.php
+++ b/src/Models/RateLimitError.php
@@ -1,0 +1,38 @@
+<?php
+namespace SturentsLib\Api\Models;
+
+/**
+ * ** This file was generated automatically, you might want to avoid editing it **
+ *
+ * This endpoint is rate limited. Please try again after the specified time
+ */
+class RateLimitError extends SwaggerModel
+{
+	/**
+	 * Message indicating the rate limit has been exceeded and when to try again
+	 * @var string
+	 */
+	protected $error = '';
+
+
+	/**
+	 * @return string
+	 */
+	public function getError()
+	{
+		return $this->error;
+	}
+
+
+	/**
+	 * @param string $error
+	 *
+	 * @return $this
+	 */
+	public function setError($error)
+	{
+		$this->error = $error;
+
+		return $this;
+	}
+}

--- a/src/Models/ScheduleOption.php
+++ b/src/Models/ScheduleOption.php
@@ -5,7 +5,7 @@ namespace SturentsLib\Api\Models;
  * ** This file was generated automatically, you might want to avoid editing it **
  *
  * A schedule that can be used to pay rent for a contract, with specific
- * rules regarding whether it requires a guarantor or allows use of Housing Hand
+ * rules regarding whether it requires a guarantor
  */
 class ScheduleOption extends SwaggerModel
 {
@@ -29,17 +29,6 @@ class ScheduleOption extends SwaggerModel
 	 * @required
 	 */
 	protected $require_guarantor;
-
-	/**
-	 * The Housing Hand service is a partnership offered by StuRents
-	 * in order to provide guarantors for tenants who are otherwise
-	 * unable to acquire one. When a tenancy is created this field
-	 * states whether Housing Hand is permitted, if set to true,
-	 * not permitted if set to false.
-	 *
-	 * @var bool
-	 */
-	protected $housing_hand = false;
 
 
 	/**
@@ -81,28 +70,6 @@ class ScheduleOption extends SwaggerModel
 	public function setRequireGuarantor($require_guarantor)
 	{
 		$this->require_guarantor = $require_guarantor;
-
-		return $this;
-	}
-
-
-	/**
-	 * @return bool
-	 */
-	public function getHousingHand()
-	{
-		return $this->housing_hand;
-	}
-
-
-	/**
-	 * @param bool $housing_hand
-	 *
-	 * @return $this
-	 */
-	public function setHousingHand($housing_hand)
-	{
-		$this->housing_hand = $housing_hand;
 
 		return $this;
 	}

--- a/src/Requests/GetProperties.php
+++ b/src/Requests/GetProperties.php
@@ -30,7 +30,7 @@ class GetProperties extends SwaggerRequest
 
 
 	/**
-	 * @return \SturentsLib\Api\Models\ListProperties|\SturentsLib\Api\Models\Error|\SturentsLib\Api\Models\AuthError|\SturentsLib\Api\Models\GetError|list<\SturentsLib\Api\Models\ListProperties>|list<\SturentsLib\Api\Models\Error>|list<\SturentsLib\Api\Models\AuthError>|list<\SturentsLib\Api\Models\GetError>
+	 * @return \SturentsLib\Api\Models\ListProperties|\SturentsLib\Api\Models\Error|\SturentsLib\Api\Models\AuthError|\SturentsLib\Api\Models\GetError|\SturentsLib\Api\Models\RateLimitError|list<\SturentsLib\Api\Models\ListProperties>|list<\SturentsLib\Api\Models\Error>|list<\SturentsLib\Api\Models\AuthError>|list<\SturentsLib\Api\Models\GetError>|list<\SturentsLib\Api\Models\RateLimitError>
 	 */
 	public function sendWith(SwaggerClient $client)
 	{
@@ -39,6 +39,7 @@ class GetProperties extends SwaggerRequest
 			'400' => \SturentsLib\Api\Models\Error::class,
 			'401' => \SturentsLib\Api\Models\AuthError::class,
 			'404' => \SturentsLib\Api\Models\GetError::class,
+			'429' => \SturentsLib\Api\Models\RateLimitError::class,
 			'default' => \SturentsLib\Api\Models\Error::class
 		]);
 	}

--- a/swagger/api-channel.yml
+++ b/swagger/api-channel.yml
@@ -115,6 +115,8 @@ paths:
           $ref: '#/definitions/AuthError'
         '404':
           $ref: '#/definitions/GetError'
+        '429':
+          $ref: '#/definitions/RateLimitError'
         default:
           $ref: '#/definitions/Error'
   /facilities:
@@ -172,7 +174,15 @@ definitions:
     properties:
       error:
         type: string
-        description: Another error message not related to authenticaiton
+        description: Another error message not related to authentication
+  RateLimitError:
+    description: |
+      This endpoint is rate limited. Please try again after the specified time
+    type: object
+    properties:
+      error:
+        type: string
+        description: Message indicating the rate limit has been exceeded and when to try again
   AuthError:
     description: |
       The key supplied did not match the property manager or channel

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -110,6 +110,8 @@ paths:
           $ref: '#/definitions/AuthError'
         '404':
           $ref: '#/definitions/GetError'
+        '429':
+          $ref: '#/definitions/RateLimitError'
         default:
           $ref: '#/definitions/Error'
   /summary:
@@ -718,6 +720,14 @@ definitions:
         description: Keyed by field name (collapsed using . characters)
         items:
           type: string
+  RateLimitError:
+    description: |
+      This endpoint is rate limited. Please try again after the specified time
+    type: object
+    properties:
+      error:
+        type: string
+        description: Message indicating the rate limit has been exceeded and when to try again
   ListProperties:
     type: object
     properties:


### PR DESCRIPTION
New rate limit response object:
```
class SturentsLib\Api\Models\RateLimitError#41 (2) {
  private bool $_is_error =>
  bool(true)
  protected $error =>
  string(65) "Rate limit reached for this query. Try again at or after 12:36pm."
}
```

housing hand yml changes from previous commit that weren't gen'd: https://github.com/sturents/api-php/commit/13b31eb2c7cb1e94fc6bf9b03db2cc37e3421ee8