### PR TITLE
add new rolling price field for initial period daily rate, make payme…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StuRents API Helper
 
-_Master branch is for v2.0 which is not available yet; please check releases for previous versions. For outbound data check 1.3.*, for inbound use 1.2.*_
+_Master branch is for v3 of the StuRents API. Please check releases for previous versions.
 
 Install using composer:
 

--- a/src/Models/Price.php
+++ b/src/Models/Price.php
@@ -12,25 +12,18 @@ namespace SturentsLib\Api\Models;
 class Price extends SwaggerModel
 {
 	/**
-	 * For fixed-term contracts, this is the monetary value indicating
+	 * A monetary value indicating
 	 * the weekly rent each tenant will be expected to pay during their
-	 * tenancy in the property.
+	 * fixed-term tenancy. This is required if is_fixed_term is true.
 	 *
-	 * For rolling contracts, this is the monetary value indicating the
-	 * daily rent each tenant will pay for the first payment period.
-	 * The first payment period covers the rent from the start date to
-	 * the day before the first rolling monthly payment day. The first payment rent
-	 * is calculated based on the number of days in the period multiplied by the per day rate.
-	 *
-	 * Whether fixed or rolling, this does not mean the rent is paid weekly or daily - the StuRents
+	 * This does not mean the rent is paid weekly - the StuRents
 	 * search and profiles display all rents as a weekly amount and this
 	 * will be used to calculate total and scheduled payments when
 	 * creating a tenancy and/or rent collection for the property
 	 *
-	 * @var float
-	 * @required
+	 * @var ?float
 	 */
-	protected $price_per_person_per_week;
+	protected $price_per_person_per_week = 0.0;
 
 	/**
 	 * A monetary value indicating the deposit each tenant will be
@@ -51,10 +44,10 @@ class Price extends SwaggerModel
 
 	/**
 	 * A monetary value indicating the monthly rent each tenant will
-	 * be expected to pay during their rolling tenancy in the property.
-	 * This is required if is_fixed_term is false
+	 * be expected to pay during their rolling tenancy.
+	 * This is required if is_fixed_term is false.
 	 *
-	 * The StuRents search and profiles display all rents as a weekly amount and this
+	 * The StuRents search and profiles display all rents as a weekly amount and this field's value
 	 * will be used to calculate total and scheduled payments when
 	 * creating a tenancy and/or rent collection for the property.
 	 *
@@ -62,9 +55,22 @@ class Price extends SwaggerModel
 	 */
 	protected $rolling_price_per_person_per_month = 0.0;
 
+	/**
+	 * A monetary value indicating the
+	 * daily rent each tenant will pay for the first payment period for a rolling tenancy.
+	 * This is required if is_fixed_term is false.
+	 *
+	 * The first payment period covers the rent from the start date to
+	 * the day before the first rolling monthly payment day. The first payment rent
+	 * is calculated based on the number of days in the period multiplied by the per day rate.
+	 *
+	 * @var ?float
+	 */
+	protected $rolling_price_initial_period_per_person_per_day = 0.0;
+
 
 	/**
-	 * @return float
+	 * @return ?float
 	 */
 	public function getPricePerPersonPerWeek()
 	{
@@ -73,7 +79,7 @@ class Price extends SwaggerModel
 
 
 	/**
-	 * @param float $price_per_person_per_week
+	 * @param ?float $price_per_person_per_week
 	 *
 	 * @return $this
 	 */
@@ -146,6 +152,28 @@ class Price extends SwaggerModel
 	public function setRollingPricePerPersonPerMonth($rolling_price_per_person_per_month)
 	{
 		$this->rolling_price_per_person_per_month = $rolling_price_per_person_per_month;
+
+		return $this;
+	}
+
+
+	/**
+	 * @return ?float
+	 */
+	public function getRollingPriceInitialPeriodPerPersonPerDay()
+	{
+		return $this->rolling_price_initial_period_per_person_per_day;
+	}
+
+
+	/**
+	 * @param ?float $rolling_price_initial_period_per_person_per_day
+	 *
+	 * @return $this
+	 */
+	public function setRollingPriceInitialPeriodPerPersonPerDay($rolling_price_initial_period_per_person_per_day)
+	{
+		$this->rolling_price_initial_period_per_person_per_day = $rolling_price_initial_period_per_person_per_day;
 
 		return $this;
 	}

--- a/swagger/api-channel.yml
+++ b/swagger/api-channel.yml
@@ -660,26 +660,19 @@ definitions:
       this will apply to all rooms. That field may be left null
       if the "room_prices" array is used instead.
     type: object
-    required:
-      - price_per_person_per_week
     properties:
       price_per_person_per_week:
         type: number
+        nullable: true
         description: |
-          For fixed-term contracts, this is the monetary value indicating 
+          A monetary value indicating 
           the weekly rent each tenant will be expected to pay during their 
-          tenancy in the property.
-          
-          For rolling contracts, this is the monetary value indicating the 
-          daily rent each tenant will pay for the first payment period.
-          The first payment period covers the rent from the start date to 
-          the day before the first rolling monthly payment day. The first payment rent 
-          is calculated based on the number of days in the period multiplied by the per day rate.
+          fixed-term tenancy. This is required if is_fixed_term is true.
 
-          Whether fixed or rolling, this does not mean the rent is paid weekly or daily - the StuRents
+          This does not mean the rent is paid weekly - the StuRents
           search and profiles display all rents as a weekly amount and this
           will be used to calculate total and scheduled payments when
-          creating a tenancy and/or rent collection for the property.
+          creating a tenancy and/or rent collection for the property
       deposit_per_person:
         type: number
         description: |
@@ -693,14 +686,26 @@ definitions:
           rent the property
       rolling_price_per_person_per_month:
         type: number
+        nullable: true
         description: |
           A monetary value indicating the monthly rent each tenant will
-          be expected to pay during their rolling tenancy in the property.
-          This is required if is_fixed_term is false
+          be expected to pay during their rolling tenancy.
+          This is required if is_fixed_term is false.
 
-          The StuRents search and profiles display all rents as a weekly amount and this
+          The StuRents search and profiles display all rents as a weekly amount and this field's value
           will be used to calculate total and scheduled payments when
           creating a tenancy and/or rent collection for the property.
+      rolling_price_initial_period_per_person_per_day:
+        type: number
+        nullable: true
+        description: |
+          A monetary value indicating the 
+          daily rent each tenant will pay for the first payment period for a rolling tenancy.
+          This is required if is_fixed_term is false.
+
+          The first payment period covers the rent from the start date to 
+          the day before the first rolling monthly payment day. The first payment rent 
+          is calculated based on the number of days in the period multiplied by the per day rate.
   PriceOutbound:
     description: |
       When fetching property details this describes a Price attached

--- a/swagger/api-display.yml
+++ b/swagger/api-display.yml
@@ -556,26 +556,19 @@ definitions:
       this will apply to all rooms. That field may be left null
       if the "room_prices" array is used instead.
     type: object
-    required:
-      - price_per_person_per_week
     properties:
       price_per_person_per_week:
         type: number
+        nullable: true
         description: |
-          For fixed-term contracts, this is the monetary value indicating 
+          A monetary value indicating 
           the weekly rent each tenant will be expected to pay during their 
-          tenancy in the property.
-          
-          For rolling contracts, this is the monetary value indicating the 
-          daily rent each tenant will pay for the first payment period.
-          The first payment period covers the rent from the start date to 
-          the day before the first rolling monthly payment day. The first payment rent 
-          is calculated based on the number of days in the period multiplied by the per day rate.
+          fixed-term tenancy. This is required if is_fixed_term is true.
 
-          Whether fixed or rolling, this does not mean the rent is paid weekly or daily - the StuRents
+          This does not mean the rent is paid weekly - the StuRents
           search and profiles display all rents as a weekly amount and this
           will be used to calculate total and scheduled payments when
-          creating a tenancy and/or rent collection for the property.
+          creating a tenancy and/or rent collection for the property
       deposit_per_person:
         type: number
         description: |
@@ -589,14 +582,26 @@ definitions:
           rent the property
       rolling_price_per_person_per_month:
         type: number
+        nullable: true
         description: |
           A monetary value indicating the monthly rent each tenant will
-          be expected to pay during their rolling tenancy in the property.
-          This is required if is_fixed_term is false
+          be expected to pay during their rolling tenancy.
+          This is required if is_fixed_term is false.
 
-          The StuRents search and profiles display all rents as a weekly amount and this
+          The StuRents search and profiles display all rents as a weekly amount and this field's value
           will be used to calculate total and scheduled payments when
           creating a tenancy and/or rent collection for the property.
+      rolling_price_initial_period_per_person_per_day:
+        type: number
+        nullable: true
+        description: |
+          A monetary value indicating the 
+          daily rent each tenant will pay for the first payment period for a rolling tenancy.
+          This is required if is_fixed_term is false.
+
+          The first payment period covers the rent from the start date to 
+          the day before the first rolling monthly payment day. The first payment rent 
+          is calculated based on the number of days in the period multiplied by the per day rate.
   PriceOutbound:
     description: |
       When fetching property details this describes a Price attached

--- a/swagger/api-upload.yml
+++ b/swagger/api-upload.yml
@@ -1249,26 +1249,19 @@ definitions:
       this will apply to all rooms. That field may be left null
       if the "room_prices" array is used instead.
     type: object
-    required:
-      - price_per_person_per_week
     properties:
       price_per_person_per_week:
         type: number
+        nullable: true
         description: |
-          For fixed-term contracts, this is the monetary value indicating 
+          A monetary value indicating 
           the weekly rent each tenant will be expected to pay during their 
-          tenancy in the property.
-          
-          For rolling contracts, this is the monetary value indicating the 
-          daily rent each tenant will pay for the first payment period.
-          The first payment period covers the rent from the start date to 
-          the day before the first rolling monthly payment day. The first payment rent 
-          is calculated based on the number of days in the period multiplied by the per day rate.
+          fixed-term tenancy. This is required if is_fixed_term is true.
 
-          Whether fixed or rolling, this does not mean the rent is paid weekly or daily - the StuRents
+          This does not mean the rent is paid weekly - the StuRents
           search and profiles display all rents as a weekly amount and this
           will be used to calculate total and scheduled payments when
-          creating a tenancy and/or rent collection for the property.
+          creating a tenancy and/or rent collection for the property
       deposit_per_person:
         type: number
         description: |
@@ -1282,14 +1275,26 @@ definitions:
           rent the property
       rolling_price_per_person_per_month:
         type: number
+        nullable: true
         description: |
           A monetary value indicating the monthly rent each tenant will
-          be expected to pay during their rolling tenancy in the property.
-          This is required if is_fixed_term is false
+          be expected to pay during their rolling tenancy.
+          This is required if is_fixed_term is false.
 
-          The StuRents search and profiles display all rents as a weekly amount and this
+          The StuRents search and profiles display all rents as a weekly amount and this field's value
           will be used to calculate total and scheduled payments when
           creating a tenancy and/or rent collection for the property.
+      rolling_price_initial_period_per_person_per_day:
+        type: number
+        nullable: true
+        description: |
+          A monetary value indicating the 
+          daily rent each tenant will pay for the first payment period for a rolling tenancy.
+          This is required if is_fixed_term is false.
+
+          The first payment period covers the rent from the start date to 
+          the day before the first rolling monthly payment day. The first payment rent 
+          is calculated based on the number of days in the period multiplied by the per day rate.
   PriceOutbound:
     description: |
       When fetching property details this describes a Price attached

--- a/swagger/api.yml
+++ b/swagger/api.yml
@@ -1330,23 +1330,16 @@ definitions:
       this will apply to all rooms. That field may be left null
       if the "room_prices" array is used instead.
     type: object
-    required:
-      - price_per_person_per_week
     properties:
       price_per_person_per_week:
         type: number
+        nullable: true
         description: |
-          For fixed-term contracts, this is the monetary value indicating 
+          A monetary value indicating 
           the weekly rent each tenant will be expected to pay during their 
-          tenancy in the property.
-          
-          For rolling contracts, this is the monetary value indicating the 
-          daily rent each tenant will pay for the first payment period.
-          The first payment period covers the rent from the start date to 
-          the day before the first rolling monthly payment day. The first payment rent 
-          is calculated based on the number of days in the period multiplied by the per day rate.
+          fixed-term tenancy. This is required if is_fixed_term is true.
 
-          Whether fixed or rolling, this does not mean the rent is paid weekly or daily - the StuRents
+          This does not mean the rent is paid weekly - the StuRents
           search and profiles display all rents as a weekly amount and this
           will be used to calculate total and scheduled payments when
           creating a tenancy and/or rent collection for the property
@@ -1366,12 +1359,23 @@ definitions:
         nullable: true
         description: |
           A monetary value indicating the monthly rent each tenant will
-          be expected to pay during their rolling tenancy in the property.
-          This is required if is_fixed_term is false
+          be expected to pay during their rolling tenancy.
+          This is required if is_fixed_term is false.
 
-          The StuRents search and profiles display all rents as a weekly amount and this
+          The StuRents search and profiles display all rents as a weekly amount and this field's value
           will be used to calculate total and scheduled payments when
           creating a tenancy and/or rent collection for the property.
+      rolling_price_initial_period_per_person_per_day:
+        type: number
+        nullable: true
+        description: |
+          A monetary value indicating the 
+          daily rent each tenant will pay for the first payment period for a rolling tenancy.
+          This is required if is_fixed_term is false.
+          
+          The first payment period covers the rent from the start date to 
+          the day before the first rolling monthly payment day. The first payment rent 
+          is calculated based on the number of days in the period multiplied by the per day rate.
   PriceOutbound:
     description: |
       When fetching property details this describes a Price attached


### PR DESCRIPTION
My initial attempt to get the Price modal to support rolling availabilities was confusing-  I resused the price_per_person_per_week to send the rolling DAILY initial period price. This PR updates the SDK to include the new $rolling_price_initial_period_per_person_per_day field which is for the rolling daily value. It also makes the price_per_person_per_week field nullable as it is only required for fixed contracts.

This is technically a breaking change, but given no one is using the new api version yet we can just release as a new patch or minor version