### PR TITLE
Update composer dependencies and regen Requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"guzzlehttp/guzzle": "^6.0 || ^7.0",
-		"netresearch/jsonmapper": "^1.4 || ^2.0 || ^3.0 || ^4.0 || ^5.0",
+		"guzzlehttp/guzzle": "^6.0 || ^7.0 || ^8.0",
+		"netresearch/jsonmapper": "1.4 || ^2.0 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
 		"psr/http-message": "^1.1 || ^2.0",
 		"ext-json": "*"
 	},
 	"require-dev": {
 		"roave/security-advisories": "dev-latest",
 		"sturents/swagger-php-model-generator": "^0.3",
-		"vimeo/psalm": "^6.12"
+		"psalm/phar": "^6.16"
 	},
 	"autoload": {
 		"psr-4": {

--- a/generate.php
+++ b/generate.php
@@ -3,6 +3,8 @@
 use SwaggerGen\GenerateModels;
 use SwaggerGen\GenerateRequests;
 
+// Ensure packages such as sturents/swagger-php-model-generator are upto date when generating
+shell_exec('composer update');
 require __DIR__.'/vendor/autoload.php';
 
 $namespace = "SturentsLib\\Api";

--- a/src/Requests/DeleteContract.php
+++ b/src/Requests/DeleteContract.php
@@ -44,7 +44,7 @@ class DeleteContract extends SwaggerRequest
 	public function sendWith(SwaggerClient $client)
 	{
 		return $client->make($this, [
-			'204' => '',
+			'204' => null,
 			'401' => \SturentsLib\Api\Models\AuthError::class,
 			'404' => \SturentsLib\Api\Models\Error::class,
 			'default' => \SturentsLib\Api\Models\Error::class

--- a/src/Requests/DeleteMedia.php
+++ b/src/Requests/DeleteMedia.php
@@ -42,7 +42,7 @@ class DeleteMedia extends SwaggerRequest
 	public function sendWith(SwaggerClient $client)
 	{
 		return $client->make($this, [
-			'204' => '',
+			'204' => null,
 			'401' => \SturentsLib\Api\Models\AuthError::class,
 			'404' => \SturentsLib\Api\Models\Error::class,
 			'default' => \SturentsLib\Api\Models\Error::class

--- a/src/Requests/DeleteRoom.php
+++ b/src/Requests/DeleteRoom.php
@@ -43,7 +43,7 @@ class DeleteRoom extends SwaggerRequest
 	public function sendWith(SwaggerClient $client)
 	{
 		return $client->make($this, [
-			'204' => '',
+			'204' => null,
 			'401' => \SturentsLib\Api\Models\AuthError::class,
 			'404' => \SturentsLib\Api\Models\Error::class,
 			'default' => \SturentsLib\Api\Models\Error::class

--- a/src/Requests/GetFacilities.php
+++ b/src/Requests/GetFacilities.php
@@ -17,7 +17,7 @@ class GetFacilities extends SwaggerRequest
 	public function sendWith(SwaggerClient $client)
 	{
 		return $client->make($this, [
-			'200' => ''
+			'200' => null
 		]);
 	}
 }

--- a/src/Requests/PatchContract.php
+++ b/src/Requests/PatchContract.php
@@ -35,7 +35,7 @@ class PatchContract extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\ContractCreation $contract)
 	{
-		$this->body = json_encode($contract);
+		$this->body = json_encode($contract, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PatchProperty.php
+++ b/src/Requests/PatchProperty.php
@@ -26,7 +26,7 @@ class PatchProperty extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\Property $property)
 	{
-		$this->body = json_encode($property);
+		$this->body = json_encode($property, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PatchRoom.php
+++ b/src/Requests/PatchRoom.php
@@ -35,7 +35,7 @@ class PatchRoom extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\Room $room)
 	{
-		$this->body = json_encode($room);
+		$this->body = json_encode($room, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PutContract.php
+++ b/src/Requests/PutContract.php
@@ -26,7 +26,7 @@ class PutContract extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\ContractCreation $contract)
 	{
-		$this->body = json_encode($contract);
+		$this->body = json_encode($contract, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PutMedia.php
+++ b/src/Requests/PutMedia.php
@@ -26,7 +26,7 @@ class PutMedia extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\MediaUpload $mediaupload)
 	{
-		$this->body = json_encode($mediaupload);
+		$this->body = json_encode($mediaupload, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PutProperty.php
+++ b/src/Requests/PutProperty.php
@@ -15,7 +15,7 @@ class PutProperty extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\PropertyCreation $property)
 	{
-		$this->body = json_encode($property);
+		$this->body = json_encode($property, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/PutRoom.php
+++ b/src/Requests/PutRoom.php
@@ -26,7 +26,7 @@ class PutRoom extends SwaggerRequest
 	 */
 	public function setBody(\SturentsLib\Api\Models\Room $room)
 	{
-		$this->body = json_encode($room);
+		$this->body = json_encode($room, JSON_THROW_ON_ERROR);
 	}
 
 

--- a/src/Requests/SwaggerClient.php
+++ b/src/Requests/SwaggerClient.php
@@ -9,7 +9,7 @@ interface SwaggerClient {
 	/**
 	 * @template T of SwaggerModel
 	 *
-	 * @param array<array-key, class-string<T>|''> $response_models
+	 * @param array<array-key, class-string<T>|null> $response_models
 	 * @return T|list<T>
 	 */
 	public function make(SwaggerRequest $swagger, array $response_models);

--- a/src/SturentsClient.php
+++ b/src/SturentsClient.php
@@ -91,7 +91,8 @@ abstract class SturentsClient implements SwaggerClient {
 		}
 		catch (ClientException $e) {
 			$this->debug_request_exception = $e;
-			if (!$e->hasResponse()){
+            // In Guzzle 8 ClientException always has a ResponseInterface
+			if (method_exists($e, 'hasResponse') && !$e->hasResponse()){
 				throw new SturentsException("The StuRents API could not be reached. The client reported: {$e->getMessage()}", self::EX_CODE_RESPONSE);
 			}
 


### PR DESCRIPTION
This PR allows projects using this to use the latest version of `guzzlehttp/guzzle` and `netresearch/jsonmapper`

- Changes to Requests are due to a previous Generate on an older version of the `swagger-php-model-generator` package
- Psalm changed to phar version to allow installing latest `netresearch/jsonmapper`
- Forced `composer update` to be ran on generate script to ensure older versions of Requests do not get generated again